### PR TITLE
Cobertura: Strip Method Signature

### DIFF
--- a/uploader.sh
+++ b/uploader.sh
@@ -470,6 +470,7 @@ if [[ "$coverage_path" == *.xml.otterwise ]]; then
             awk -v base_dir="$base_dir_for_replacement" '/<package / { gsub(/name="[^"]*"/, "name=\"\"") }
                                        /<class / { gsub(/name="[^"]*"/, "name=\"\"") }
                                        /<method / { gsub(/name="[^"]*"/, "name=\"\"") }
+                                       /<method / { gsub(/signature="[^"]*"/, "signature=\"\"") }
                                        /<source>/ { gsub(base_dir, "") } 1' "$input_file" > tmpfile && mv tmpfile "$input_file"
                                                    
             if test "${quiet:-0}" != "1"; then


### PR DESCRIPTION
Cobertura formats often contain method signature, which will expose what attributes are expected when calling the method. 
An example can be:

```xml
<method name="__construct" signature="App\Models\Repository $repository, App\Models\PullRequest $pullRequest" line-rate="1" branch-rate="0" complexity="1">
```

Here we see that the constructor expects a Repository and PullRequest.

This goes against the OtterWise goals of stripping ALL irrelevant code from coverage files we ingress.