### PR TITLE
Fix PR number eventually being set to base/head branch name instead of PR number

### DIFF
--- a/uploader.sh
+++ b/uploader.sh
@@ -165,11 +165,14 @@ elif [ -n "$(printenv GITHUB_ACTIONS | xargs)" ]; then
         if test "${quiet:-0}" != "1"; then
             echo "  Found Pull Request"
         fi
-        IFS='/'
-        read -r -a refs <<<"${github_ref}"
-        ci_pr="${refs[2]}"
-        echo $(jq --raw-output .number "$GITHUB_EVENT_PATH")
+
         ci_pr=$(jq --raw-output .number "$GITHUB_EVENT_PATH")
+        
+        if test "$ci_pr" == ""; then
+            IFS='/'
+            read -r -a refs <<<"${github_ref}"
+            ci_pr="${refs[2]}"
+        fi
 
         merge_message="$(git show --no-patch --format=%P | xargs)"
 

--- a/uploader.sh
+++ b/uploader.sh
@@ -168,6 +168,10 @@ elif [ -n "$(printenv GITHUB_ACTIONS | xargs)" ]; then
         IFS='/'
         read -r -a refs <<<"${github_ref}"
         ci_pr="${refs[2]}"
+        echo "${refs[0]}"
+        echo "${refs[1]}"
+        echo "${refs[2]}"
+        echo "${refs[3]}"
 
         merge_message="$(git show --no-patch --format=%P | xargs)"
 

--- a/uploader.sh
+++ b/uploader.sh
@@ -168,10 +168,8 @@ elif [ -n "$(printenv GITHUB_ACTIONS | xargs)" ]; then
         IFS='/'
         read -r -a refs <<<"${github_ref}"
         ci_pr="${refs[2]}"
-        echo "${refs[0]}"
-        echo "${refs[1]}"
-        echo "${refs[2]}"
-        echo "${refs[3]}"
+        echo $(jq --raw-output .number "$GITHUB_EVENT_PATH")
+        ci_pr=$(jq --raw-output .number "$GITHUB_EVENT_PATH")
 
         merge_message="$(git show --no-patch --format=%P | xargs)"
 

--- a/uploader.sh
+++ b/uploader.sh
@@ -165,10 +165,18 @@ elif [ -n "$(printenv GITHUB_ACTIONS | xargs)" ]; then
         if test "${quiet:-0}" != "1"; then
             echo "  Found Pull Request"
         fi
+    
+        if test "${quiet:-0}" != "1"; then
+            echo "  Using GITHUB_EVENT_PATH for parsing Pull Request number"
+        fi
 
         ci_pr=$(jq --raw-output .number "$GITHUB_EVENT_PATH")
         
-        if test "$ci_pr" == ""; then
+        if [[ -z "$ci_pr" || ! "$ci_pr" =~ ^[0-9]+$ ]]; then
+            if test "${quiet:-0}" != "1"; then
+                echo "  Using refs for parsing Pull Request number"
+            fi
+            
             IFS='/'
             read -r -a refs <<<"${github_ref}"
             ci_pr="${refs[2]}"


### PR DESCRIPTION
This fixes a bug that causes GitHub Actions PR numbers to not be set correctly. It is super rare (seen in less than 0.001% of PR builds submitted), but unacceptable nonetheless.

I could not pinpoint exactly what caused it. Even when replicating the exact pull request sequence ([feature] -> development -> staging -> main) it did not happen again.

Maybe it is GitHub actions having rare bugs, or maybe the branch names cause issues for some reason.. not sure..

This change however does work much more reliably, and uses the old method as fallback.